### PR TITLE
feat: add Room class

### DIFF
--- a/server.py
+++ b/server.py
@@ -182,7 +182,7 @@ class Room:
             if client:
                 return client
             else:
-                None
+                return None
 
     def get_clients(self):
         return {

--- a/server.py
+++ b/server.py
@@ -166,29 +166,36 @@ class RoomManager:
         """
         pass
 
+# -------------------------------
+# ルームクラス
+# -------------------------------
 class Room:
-    def add_client(self, token, username, addr=None):
-        """
-        ルームに新しいクライアントを追加する。
+    def __init__(self, name, host_token):
+        self.name = name
+        self.host_token = host_token
+        self.clients = {}
 
-        処理内容:
-        - tokenをキーにクライアント情報を保存
-        - username, addr, 最終通信時刻を記録
-        """
-        pass
+    def get_clients(self):
+        return self.clients.items()
+
+    def add_client(self, token, username, addr=None):
+        self.clients[token] = {
+            "username": username,
+            "addr": addr,
+            "last_seen": time.time()
+        }
+        print(f'+ added {self.clients[token]["username"]}')
+        return
 
     def delete_client(self, token):
-        """
-        クライアントをルームから削除する。
+        if token in self.clients:
+            username = self.clients[token]["username"]
+            del self.clients[token]
 
-        処理内容:
-        - tokenに対応するクライアントを削除
-        - ホストが退出した場合はルーム削除を通知
+            if token == self.host_token:
+                return "HOST_LEFT", f"- room host {username} left."
 
-        戻り値:
-        - ("HOST_LEFT", メッセージ) または ("OK", メッセージ)
-        """
-        pass
+            return "OK", f"- {username} left."
 
 
 

--- a/server.py
+++ b/server.py
@@ -174,28 +174,31 @@ class Room:
         self.name = name
         self.host_token = host_token
         self.clients = {}
+        self.lock = threading.Lock()
 
     def get_clients(self):
         return self.clients.items()
 
     def add_client(self, token, username, addr=None):
-        self.clients[token] = {
-            "username": username,
-            "addr": addr,
-            "last_seen": time.time()
-        }
+        with self.lock:
+            self.clients[token] = {
+                "username": username,
+                "addr": addr,
+                "last_seen": time.time()
+            }
         print(f'+ added {self.clients[token]["username"]}')
         return
 
     def delete_client(self, token):
-        if token in self.clients:
-            username = self.clients[token]["username"]
-            del self.clients[token]
+        with self.lock:
+            if token in self.clients:
+                username = self.clients[token]["username"]
+                del self.clients[token]
 
-            if token == self.host_token:
-                return "HOST_LEFT", f"- room host {username} left."
+                if token == self.host_token:
+                    return "HOST_LEFT", f"- room host {username} left."
 
-            return "OK", f"- {username} left."
+                return "OK", f"- {username} left."
 
 
 

--- a/server.py
+++ b/server.py
@@ -174,20 +174,40 @@ class Room:
         self.name = name
         self.host_token = host_token
         self.clients = {}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
+
+    def get_client(self, token):
+        with self.lock:
+            client = self.clients.get(token)
+            if client:
+                return client
+            else:
+                None
 
     def get_clients(self):
-        return self.clients.items()
+        return {
+            key: dict(value)
+            for key, value in self.clients.items()
+        }
+
+    def has_clients(self, token):
+        with self.lock:
+            return token in self.clients
 
     def add_client(self, token, username, addr=None):
         with self.lock:
+            # usernameの重複チェック
+            for client in self.clients.values():
+                if client["username"] == username:
+                    return False, username
+
             self.clients[token] = {
                 "username": username,
                 "addr": addr,
                 "last_seen": time.time()
             }
-        print(f'+ added {self.clients[token]["username"]}')
-        return
+            print(f'+ added {self.clients[token]["username"]}')
+            return True, username
 
     def delete_client(self, token):
         with self.lock:
@@ -196,9 +216,11 @@ class Room:
                 del self.clients[token]
 
                 if token == self.host_token:
-                    return "HOST_LEFT", f"- room host {username} left."
+                    return "HOST_LEFT", username
 
-                return "OK", f"- {username} left."
+                return "OK", username
+            else:
+                return "NOT_FOUND", username
 
 
 


### PR DESCRIPTION
個々のチャットルームを管理するための、Roomクラスを作成しました。
ルーム名とホストのトークンを渡すことで初期化（作成）されます。
ThreadingのロッキングはRoomManagerクラスのメソッドで行います。

### `add_client`
追加したいクライアントのユーザーネームとトークンを渡すことで、clientsにルームのメンバーとして追加します。

### `del_client`
削除したいクライアントのトークンを渡すと、存在を確認して削除を実行し、メッセージを返します。
#### 返り値
- 1つ目の返り値（`"HOST_LEFT"` or `"OK"`）：
削除したクライアントがホストだった場合の処理分岐のためのマーカーの意図で作成しました。
- 2つ目の返り値（username）
クライアントがルームから退室したことを、他のクライアントに知らせるメッセージに使うことを意図して作成しました。