### PR TITLE
fix: standardize variable names in RoomManager class.

### DIFF
--- a/server.py
+++ b/server.py
@@ -128,8 +128,8 @@ class RoomManager:
 
             host_token = secrets.token_hex(16)
             room = Room(room_name, host_token)
-            success, _ = room.add_client(host_token, username)
-            if success:
+            ok, _ = room.add_client(host_token, username)
+            if ok:
                 print(f'[Success] room name "{room_name}" created.')
                 self.rooms[room_name] = room
                 return True, host_token


### PR DESCRIPTION
`create_room()`と`join_room()`で、処理結果を代入する変数名が異なっていたため、`ok`で統一しました。