### PR TITLE
feat: add room list display

### DIFF
--- a/client.py
+++ b/client.py
@@ -8,73 +8,98 @@ from protocol import TCRP, UCRP
 class TCP_Client:
     HOST = "127.0.0.1"
     PORT = 9001
-    
-    def __init__(self, username, operation, room_name):
-        self.username = username
-        self.operation = operation
-        self.room_name = room_name
+
+    def __init__(self):
+        self.username = None
+        self.room_name = None
         self.token = None
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        
-        """
-        TCPクライアントの初期化を行う。
-
-        初期化内容:
-        - ユーザー名
-        - 操作種別（ルーム作成 or 参加）
-        - ルーム名
-        - Token（初期はNone）
-        - TCPソケット生成
-        """
-        pass
 
     def connect(self):
         try:
             self.sock.connect((self.HOST,self.PORT))
+            print(f"[Connected] {self.HOST}:{self.PORT} (TCP)")
             return True
         except Exception:
+            print(f"[Failure] Can't connected.")
             return False
-        
-        """
-        TCPサーバに接続する。
 
-        返り値
-        - 接続成功ならTrue
-        - 失敗ならFalse
-        """
-        pass
+    @staticmethod
+    def input_operation(nums):
+        while True:
+            try:
+                operation = int(input(f"> Operation ({" or ".join(map(str, nums))}): "))
+                if operation in nums:
+                    return operation
+            except ValueError:
+                pass
+            print(f"[Failure] invalid input. you can enter {" or ".join(map(str, nums))}.")
 
     def start(self):
         try:
+            print("=== Online Chat Messenger ===")
+            print("\n[ Operation List ]")
+            print("- 1: Create room.")
+            print("- 2: Join room.")
+            print("- 0: End system.\n")
+
+            operation = self.input_operation([1, 2, 0])
+            if operation == 0:
+                return 0
+
             #サーバにリクエスト送信
             TCRP.send_packet(
                 self.sock,
                 self.room_name,
-                self.operation,
-                0, #request
+                operation,
+                TCRP.STATE["request"], #request
                 self.username
-            )    
+                )
+
             #応答受信
-            operation, state, room_name, payload = TRCP.recv_packet(self.sock)
-            
-            if state == 2: #success
+            operation, state, _, payload = TCRP.recv_packet(self.sock)
+
+            if not payload:
+                pass
+            elif payload:
+                if len(payload) == 1 and payload[0] == "The room has not been created yet.":
+                    print(f"\n[Not exist] {payload[0]}\n")
+                    print("[ Operation List ]")
+                    print("- 1: Create room.")
+                    print("- 0: End system.\n")
+                    operation = self.input_operation([1, 0])
+                    if operation == 0:
+                        return 0
+                else:
+                    print("[ Room List ]")
+                    for item in payload:
+                        print(f"- {item}")
+
+            self.room_name = input("> Room name: ")
+            self.username = input("> User name: ")
+
+            TCRP.send_packet(
+                self.sock,
+                self.room_name,
+                operation,
+                TCRP.STATE["request"],
+                self.username
+            )
+
+            operation, state, room_name, payload = TCRP.recv_packet(self.sock)
+
+            if state == TCRP.STATE["complete"]: #success
                 self.token = payload
                 return True
             else:
-                print(f"[Failure]{payload}")
+                print(payload)
                 return False
+        except KeyboardInterrupt:
+            print("\nCtrl+C received.\nChat ended.")
+            return 0
         finally:
             self.sock.close()
-            
-        """
-        サーバにリクエストを送信し、トークンを取得する。
-
-        処理内容:
-        - リクエスト送信
-        - 応答受信
-        - トークン取得
-        """
-        pass
+            print(f"[Disconnected] {self.HOST}:{self.PORT} (TCP)")
 
     def get_token(self):
         return self.token
@@ -140,30 +165,10 @@ class UDP_Client:
 # -------------------------------
 class ChatClient:
     def run(self):
-        # ユーザ入力start
-        # 既存ルームの表示機能を実装する場合、ユーザ入力（ユーザ入力start〜endまで）はTCP接続後に変更してくださいm(_ _)m
-        print("=== Online Chat Messenger ===")
-        print("[ Operation List ]")
-        print("- 1: Create room.")
-        print("- 2: Join room.")
-
-        while True:
-            try:
-                operation = int(input("> Operation (1 or 2): "))
-                if operation in (1, 2):
-                    break
-            except ValueError:
-                pass
-            print("[Failure] invalid input. you can enter 1 or 2.")
-
-        room_name = input("> Room name: ")
-        username = input("> User name: ")
-        # ユーザ入力 end
-
         # ------------------
         # ユーザ・ルーム登録
         # ------------------
-        tcp_client = TCP_Client(username, operation, room_name)
+        tcp_client = TCP_Client()
         connect = tcp_client.connect()
         if connect:
             pass
@@ -172,11 +177,14 @@ class ChatClient:
             return
 
 
-        success = tcp_client.start()
+        ok = tcp_client.start()
         # 成功していたらトークンを取得
-        if success:
+        if ok:
+            username = tcp_client.username
+            room_name = tcp_client.room_name
             token = tcp_client.get_token()
-
+        elif ok == 0:
+            return
         else:
             # 取得に失敗したら終了
             print("[Failure] Failed to obtain token.")
@@ -191,5 +199,8 @@ class ChatClient:
 
 # python3 client.pyでクライアント登録〜チャットまでの手順が開始
 if __name__ == "__main__":
-    client = ChatClient()
-    client.run()
+    try:
+        client = ChatClient()
+        client.run()
+    except KeyboardInterrupt:
+        print("\nCtrl+C received.")

--- a/client.py
+++ b/client.py
@@ -28,12 +28,12 @@ class TCP_Client:
     def input_operation(nums):
         while True:
             try:
-                operation = int(input(f"> Operation ({" or ".join(map(str, nums))}): "))
+                operation = int(input(f"> Operation ({' or '.join(map(str, nums))}): "))
                 if operation in nums:
                     return operation
             except ValueError:
                 pass
-            print(f"[Failure] invalid input. you can enter {" or ".join(map(str, nums))}.")
+            print(f"[Failure] invalid input. you can enter {' or '.join(map(str, nums))}.")
 
     def start(self):
         try:

--- a/client.py
+++ b/client.py
@@ -45,6 +45,7 @@ class TCP_Client:
 
             operation = self.input_operation([1, 2, 0])
             if operation == 0:
+                TCRP.send_packet(self.sock, self.room_name, operation, TCRP.STATE["request"], self.username)
                 return 0
 
             #サーバにリクエスト送信
@@ -69,6 +70,7 @@ class TCP_Client:
                     print("- 0: End system.\n")
                     operation = self.input_operation([1, 0])
                     if operation == 0:
+                        TCRP.send_packet(self.sock, self.room_name, operation, TCRP.STATE["request"], self.username)
                         return 0
                 else:
                     print("[ Room List ]")

--- a/protocol.py
+++ b/protocol.py
@@ -9,6 +9,7 @@ class TCRP:
     OPERATION = {
     "create_room": 1,
     "join_room": 2,
+    "end_sys": 0,
     }
 
     STATE = {

--- a/server.py
+++ b/server.py
@@ -19,15 +19,6 @@ class TCP_Server:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.bind(("127.0.0.1", self.PORT))
         self.sock.listen()
-        """
-        TCPサーバの初期化を行う。
-
-        初期化内容:
-        - RoomManagerへの参照を保持
-        - TCPソケットを生成
-        - 指定アドレスとポートにバインド
-        - 接続待ち状態（listen）にする
-        """
 
     PORT = 9001
 
@@ -42,33 +33,30 @@ class TCP_Server:
                 ).start()
         finally:
             self.sock.close()
-        """
-        TCPサーバを起動し、クライアントからの接続を待ち受ける。
-
-        - 無限ループで接続をacceptする
-        - 接続ごとにスレッドを作成し、handle_room_requestを実行する
-        - サーバ終了時はソケットを閉じる
-        """
-        pass
 
     def handle_room_request(self, conn, addr):
         try:
             operation, state, room_name, payload = TCRP.recv_packet(conn)
-            
-            username = payload
-            
-            if operation == 1:
-                success, result = self.room_manager.create_room(room_name, username)
-            elif operation == 2:
-                success, result = self.room_manager.join_room(room_name, username)
+
+            if operation == TCRP.OPERATION["create_room"]:
+                TCRP.send_packet(conn, None, operation, TCRP.STATE["response"], None)
+            elif operation == TCRP.OPERATION["join_room"]:
+                TCRP.send_packet(conn, None, operation, TCRP.STATE["response"], self.room_manager.get_room_list())
+
+            operation, state, room_name, username = TCRP.recv_packet(conn)
+
+            if operation == TCRP.OPERATION["create_room"]:
+                ok, result = self.room_manager.create_room(room_name, username)
+            elif operation == TCRP.OPERATION["join_room"]:
+                ok, result = self.room_manager.join_room(room_name, username)
             else:
-                success, result = False, "Invalid operation"
-                
-            if success:
-                TCRP.send_packet(conn, room_name, operation, 2, result)
+                ok, result = False, "Invalid operation"
+
+            if ok:
+                TCRP.send_packet(conn, room_name, operation, TCRP.STATE["complete"], result)
             else:
-                TCRP.send_packet(conn, room_name, operation, 1, result)
-                
+                TCRP.send_packet(conn, room_name, operation, TCRP.STATE["response"], result)
+
         except Exception as e:
             try:
                 TCRP.send_packet(conn, "", 0,1, str(e))
@@ -76,22 +64,7 @@ class TCP_Server:
                 pass
         finally:
             conn.close()
-                
-        """
-        クライアントからのルーム操作要求を処理する。
 
-        処理内容:
-        - TCRPプロトコル(TCRPのrecv_packet(conn))でパケットを受信
-        - operationに応じて以下を分岐
-            - ルーム作成(1) → self.room_manager.create_room
-            - ルーム参加(2) → self.room_manager.join_room
-            返り値で成功・失敗をチェックして処理を分岐
-        - 成功時はトークンを返す(state: 2)
-        - 失敗時はエラーメッセージを返す(state: 1)
-          (ルーム名・ユーザ名の重複、不正なコードなど)
-        - 最後に接続を閉じる
-        """
-        pass
 
 # -------------------------------
 # チャットメッセージング
@@ -223,6 +196,14 @@ class RoomManager:
             room = self.rooms.get(room_name)
             return None if room is None else room.get_clients()
 
+    # ルーム名を配列で取得
+    def get_room_list(self):
+        with self.lock:
+            room_list = self.rooms.keys()
+            if not room_list:
+                return ["The room has not been created yet."]
+            else:
+                return list(room_list)
 
 
 # -------------------------------
@@ -292,6 +273,8 @@ class ChatServer:
         self.room_manager = RoomManager()
 
     def run(self):
+        print("=== Online Chat Messenger Server ===")
+        print("exit with Ctrl+C. waiting message...")
         # 各サーバのインスタンスを作成。共通のルームマネージャーを持ってもらう。
         tcp_server = TCP_Server(self.room_manager)
         udp_server = UDP_Server(self.room_manager)
@@ -300,11 +283,17 @@ class ChatServer:
         threading.Thread(target=udp_server.start, daemon=True).start()
 
         # メインスレッド用ループ
-        while True:
-            time.sleep(1)
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("\nCtrl+C received.\nServer will be shut down.")
 
 
 # python3 server.pyでサーバが起動
 if __name__ == "__main__":
-    server = ChatServer()
-    server.run()
+    try:
+        server = ChatServer()
+        server.run()
+    finally:
+        ("----- end -----")

--- a/server.py
+++ b/server.py
@@ -42,6 +42,9 @@ class TCP_Server:
                 TCRP.send_packet(conn, None, operation, TCRP.STATE["response"], None)
             elif operation == TCRP.OPERATION["join_room"]:
                 TCRP.send_packet(conn, None, operation, TCRP.STATE["response"], self.room_manager.get_room_list())
+            elif operation == TCRP.OPERATION["end_sys"]:
+                print("receive end system.")
+                return
 
             operation, state, room_name, username = TCRP.recv_packet(conn)
 
@@ -49,6 +52,9 @@ class TCP_Server:
                 ok, result = self.room_manager.create_room(room_name, username)
             elif operation == TCRP.OPERATION["join_room"]:
                 ok, result = self.room_manager.join_room(room_name, username)
+            elif operation == TCRP.OPERATION["end_sys"]:
+                print("receive end system.")
+                return
             else:
                 ok, result = False, "Invalid operation"
 


### PR DESCRIPTION
operationで2（`join_room`）を選択した際に、既存のルームのリストが表示される機能を作成しました。
また、operationの選択肢に0（システムの終了）を追加してみました。

ルームが存在しなかった場合は、再度operationの入力を受け取るようにしています（1（`create_room`）or 0（システム終了））。

その他
- CLI上で実行状況を把握できるよう、各所に`print()`を書きました。
- `Ctrl+C`割り込みで、綺麗に終わるようにexceptを追加しました。
- 操作コードやステータスコードをTCRPクラスのクラス変数から取得するようにしました。
- 実行の成否が返る変数の名前を`success`→`ok`に統一しました。