### PR TITLE
feat: create client participation notification

### DIFF
--- a/client.py
+++ b/client.py
@@ -112,7 +112,6 @@ class TCP_Client:
 # 担当：kokinomu_blip
 # -------------------------------
 class UDP_Client:
-    LEAVE_MSG = 'mL8^XTqV@gGE'
 
     def __init__(self, username, room_name, token):
         self.username = username
@@ -127,7 +126,7 @@ class UDP_Client:
 
 
     def start(self):
-        send_thread = threading.Thread(target=self.send_loop)
+        send_thread = threading.Thread(target=self.send_loop, daemon=True)
         send_thread.start()
 
         try:
@@ -137,7 +136,7 @@ class UDP_Client:
             print('\nCtrl+C received.')
         finally:
             #退出用メッセージを送信
-            UCRP_packet = UCRP.build_packet(self.room_name , self.token , self.LEAVE_MSG)
+            UCRP_packet = UCRP.build_packet(self.room_name , self.token , UCRP.SYSTEM_MSG["leave_room"])
             self.sock.sendto(UCRP_packet ,(self.server_address))
             self.stop_Event.set()
 
@@ -166,6 +165,8 @@ class UDP_Client:
 
 
     def send_loop(self):
+        packet = UCRP.build_packet(self.room_name, self.token, UCRP.SYSTEM_MSG["join_room"])
+        self.sock.sendto(packet, self.server_address)
         while not self.stop_Event.is_set() :
             user_msg = input('> ')
 
@@ -173,11 +174,11 @@ class UDP_Client:
             if len(user_msg.encode('utf-8')) > 4096 :
                 print("The message is too long")
                 continue
-                
+
             #パケット生成して送信
-            UCRP_packet = UCRP.build_packet(self.room_name , self.token , user_msg) 
+            UCRP_packet = UCRP.build_packet(self.room_name , self.token , user_msg)
             self.sock.sendto(UCRP_packet ,(self.server_address))
-                
+
 
 # -------------------------------
 # メイン処理

--- a/protocol.py
+++ b/protocol.py
@@ -95,6 +95,11 @@ class TCRP:
 # UCRP (Chat room protocol / UDP)
 # -------------------------------
 class UCRP:
+    SYSTEM_MSG = {
+        "join_room": "2=6nF_du@&XS",
+        "leave_room": "mL8^XTqV@gGE",
+    }
+
     # パケットを解析する
     @staticmethod
     def parse_packet(data):

--- a/server.py
+++ b/server.py
@@ -98,14 +98,20 @@ class UDP_Server:
                 continue
 
             #退出用メッセージを受け取った時
-            if msg == 'mL8^XTqV@gGE' :
+            if msg == UCRP.SYSTEM_MSG["leave_room"]:
                 is_succese , msg = self.room_manager.leave_room(room_name , token)
                 continue
-
 
             #メッセージに名前を追加
             client = self.room_manager.get_client(room_name, token)
             username = client["username"]
+
+            if msg == UCRP.SYSTEM_MSG["join_room"]:
+                msg = f"+ [join] {username}"
+                packet = UCRP.build_packet(room_name, token, msg)
+                self.broadcast(room_name, packet)
+                continue
+
             msg = f'{username}: {msg}'
 
             packet = UCRP.build_packet(room_name , token , msg)


### PR DESCRIPTION
UDP接続に入った瞬間、クライアントが`join_msg`を送信するようにしました。
サーバは`join_msg`を受け取ると、参加したユーザの名前を含むメッセージを作成して、ルーム内の全員に通知します。

その他
- サーバとクライアントで同じ条件（join/leave_msg）を参照するため、UCRPに`SYSTEM_MSG`辞書を作成し、定数としてまとめました。
- クライアントのサブスレッドのdaemon化を見落としていたため、追記しました。

close #36 