### PR TITLE
feat: create client exit and server stop notice

### DIFF
--- a/client.py
+++ b/client.py
@@ -99,6 +99,8 @@ class TCP_Client:
         except KeyboardInterrupt:
             print("\nCtrl+C received.\nChat ended.")
             return 0
+        except ConnectionResetError:
+            print(f"- server stopped.\n--- system shutt down...")
         finally:
             self.sock.close()
             print(f"[Disconnected] {self.HOST}:{self.PORT} (TCP)")
@@ -112,6 +114,8 @@ class TCP_Client:
 # 担当：kokinomu_blip
 # -------------------------------
 class UDP_Client:
+    HOST = "127.0.0.1"
+    PORT = 9002
 
     def __init__(self, username, room_name, token):
         self.username = username
@@ -119,13 +123,14 @@ class UDP_Client:
         self.token = token
 
         self.sock = socket.socket(socket.AF_INET , socket.SOCK_DGRAM) #ソケット生成
-        self.server_address = ('127.0.0.1' , 9002) #サーバアドレス
+        self.server_address = (self.HOST , self.PORT) #サーバアドレス
 
         self.stop_Event = threading.Event()
 
 
 
     def start(self):
+        print(f"[Connected] {self.HOST}:{self.PORT} (UDP)")
         send_thread = threading.Thread(target=self.send_loop, daemon=True)
         send_thread.start()
 
@@ -139,7 +144,7 @@ class UDP_Client:
             UCRP_packet = UCRP.build_packet(self.room_name , self.token , UCRP.SYSTEM_MSG["leave_room"])
             self.sock.sendto(UCRP_packet ,(self.server_address))
             self.stop_Event.set()
-
+            print(f"[Disconnected] {self.HOST}:{self.PORT} (TCP)")
             #終了処理
             print('See you next time!')
             self.sock.close()
@@ -152,9 +157,18 @@ class UDP_Client:
                 #データを受け取り、メッセージを表示
                 data, address = self.sock.recvfrom(4096)
                 room, token, msg = UCRP.parse_packet(data)
-                # 表示したいガイドは、printで即時表示する。
-                print(msg)
-                print("> ", end="", flush=True)
+
+                if msg == UCRP.SYSTEM_MSG["host_leave"]:
+                    print(f"- host user left.\n--- close the room...")
+                    self.stop_Event.set()
+
+                elif msg == UCRP.SYSTEM_MSG["server_stop"]:
+                    print(f"- server stopped.\n--- system shutt down...")
+                    self.stop_Event.set()
+
+                else:
+                    print(msg)
+                    print("> ", end="", flush=True)
 
             except socket.timeout :
                 continue
@@ -162,17 +176,13 @@ class UDP_Client:
             except Exception as e :
                 print(e)
                 self.stop_Event.set()
-                break
 
 
     def send_loop(self):
         packet = UCRP.build_packet(self.room_name, self.token, UCRP.SYSTEM_MSG["join_room"])
         self.sock.sendto(packet, self.server_address)
         while not self.stop_Event.is_set() :
-            # before
-            # user_msg = input('> ')
 
-            # after
             print(f"> ", end="", flush=True)
             user_msg = input()
 

--- a/protocol.py
+++ b/protocol.py
@@ -98,6 +98,8 @@ class UCRP:
     SYSTEM_MSG = {
         "join_room": "2=6nF_du@&XS",
         "leave_room": "mL8^XTqV@gGE",
+        "host_leave": "Bxp>Yd+OS7Mp",
+        "server_stop": "E|8b_hglFrq=",
     }
 
     # パケットを解析する
@@ -118,7 +120,10 @@ class UCRP:
     @staticmethod
     def build_packet(room_name, token, msg):
         room_name_b = room_name.encode("utf-8")
-        token_b = token.encode("utf-8")
+        if token is None:
+            token_b = b""
+        else:
+            token_b = token.encode("utf-8")
         msg_b = msg.encode("utf-8")
 
         header = (

--- a/server.py
+++ b/server.py
@@ -101,14 +101,23 @@ class UDP_Server:
                 self.sock.sendto(packet, addr)
                 continue
 
-            #退出用メッセージを受け取った時
-            if msg == UCRP.SYSTEM_MSG["leave_room"]:
-                is_succese , msg = self.room_manager.leave_room(room_name , token)
-                continue
-
             #メッセージに名前を追加
             client = self.room_manager.get_client(room_name, token)
             username = client["username"]
+
+            #退出用メッセージを受け取った時
+            if msg == UCRP.SYSTEM_MSG["leave_room"]:
+                host_token = self.room_manager.get_host_token(room_name)
+
+                if token == host_token:
+                    notice_msg = UCRP.SYSTEM_MSG["host_leave"]
+                else:
+                    notice_msg = f"- [left] {username}"
+                self.broadcast(room_name, UCRP.build_packet(room_name, token, notice_msg))
+                ok , result_msg = self.room_manager.leave_room(room_name , token)
+                print(result_msg)
+
+                continue
 
             if msg == UCRP.SYSTEM_MSG["join_room"]:
                 msg = f"+ [join] {username}"
@@ -318,6 +327,10 @@ class ChatServer:
                 time.sleep(1)
         except KeyboardInterrupt:
             print("\nCtrl+C received.\nServer will be shut down.")
+        finally:
+            rooms = udp_server.room_manager.get_room_list()
+            for room in rooms:
+                udp_server.broadcast(room, UCRP.build_packet(room, None, UCRP.SYSTEM_MSG["server_stop"]))
 
 
 # python3 server.pyでサーバが起動


### PR DESCRIPTION
追加した通知：対象
ホストの退出（= ルームの削除）もしくはサーバの停止を通知されたクライアントはシステムを終了します。
- クライアントの退出：同じルームの全クライアント
- サーバの停止：全ルームの全クライアント

その他
- クライアント側でUDPの接続開始・終了の標準出力を追加しました
close #34 